### PR TITLE
docs: update tools links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A template for building Internet Computer canisters with Rust.
 - [Rust (1.85 or later)](https://rustup.rs/): to build the canisters
 - [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) (v0.23 or later)
 - [Just](https://just.systems/) to run scripts
-- [ic-wasm](https://github.com/dfinity/ic-wasm/releases): to bundle the canisters
-- [candid-extractor](https://github.com/dfinity/cdk-rs/releases/): to extract the candid interface of the canisters
+- [ic-wasm](https://github.com/dfinity/ic-wasm): to bundle the canisters
+- [candid-extractor](https://github.com/dfinity/candid-extractor): to extract the candid interface of the canisters
 
 ### Build canisters
 


### PR DESCRIPTION
## Description

Updated README with new links to the GitHub repo homepage of the `ic-wasm` and `candid-extractor` tools, where people can more easily find the installation instructions.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...

